### PR TITLE
Bump xercesImpl from 2.9.1 to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
       <dependency>
          <groupId>xerces</groupId>
          <artifactId>xercesImpl</artifactId>
-         <version>2.9.1</version>
+         <version>2.12.0</version>
       </dependency>
 
       <!-- spring-jdbc -->


### PR DESCRIPTION
Bumps xercesImpl from 2.9.1 to 2.12.0.

Signed-off-by: dependabot[bot] <support@github.com>